### PR TITLE
Fix wape and add post_iter_hook in backtest method

### DIFF
--- a/enda/backtesting.py
+++ b/enda/backtesting.py
@@ -187,7 +187,7 @@ class BackTesting:
             estimator: EndaEstimator,
             df: pd.DataFrame,
             target_col: str,
-            scores: Optional[Union[list[str], dict[str, str]]] = None,
+            scores: Optional[Union[list[str], dict[str, Callable]]] = None,
             process_forecast_specs: Optional[Tuple[Callable, dict]] = None,
             retrain_estimator: bool = True,
             post_iter_hook: Optional[Callable] = None,

--- a/enda/backtesting.py
+++ b/enda/backtesting.py
@@ -190,6 +190,7 @@ class BackTesting:
             scores: Optional[Union[list[str], dict[str, str]]] = None,
             process_forecast_specs: Optional[Tuple[Callable, dict]] = None,
             retrain_estimator: bool = True,
+            post_iter_hook: Optional[Callable] = None,
             verbose: bool = False,
             **kwargs
     ) -> dict[str, pd.DataFrame]:
@@ -218,6 +219,8 @@ class BackTesting:
         :param retrain_estimator: boolean, if True (default), perform a real backtesting during which an
             estimator is retrained before being used to perform a forecast. If False, the estimator must be
             already trained, and this function only serves to perform successive forecasts on test sets.
+        :param post_iter_hook: A function to be called at the end of each iteration of the backtest process.
+                               For example, it allows to clean the memory after each iteration when using h2o estimator.
         :param kwargs: extra argument to pass to the chosen split method yield_train_test_regular_split() or
             yield_train_test_periodic_split(), such as n_splits, test_size, gap_size, min_train_size,
             min_last_test_size_pct...
@@ -293,6 +296,9 @@ class BackTesting:
                 logger.info(f"Partial scores: \n{scores_df.to_string()}")
 
             scoring_result_list.append(scores_df)
+
+            if post_iter_hook is not None:
+                post_iter_hook()
 
         result_dict = {"score": pd.concat(scoring_result_list).reset_index(drop=True),
                        "forecast": pd.concat(all_forecasts_list)}

--- a/tests/test_h2o_estimator.py
+++ b/tests/test_h2o_estimator.py
@@ -213,13 +213,13 @@ class TestH2OEstimator(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             # not yet trained estimator
-            h2o_lin.get_loss_training(score_list=['rmse', 'mae', 'r2'])
+            h2o_lin.get_loss_training(scores=['rmse', 'mae', 'r2'])
 
         # train the estimator
         h2o_lin.train(self.training_df, target_col=self.target_col)
 
         # get the loss training
-        loss_training = h2o_lin.get_loss_training(score_list=['rmse', 'mae', 'r2'])
+        loss_training = h2o_lin.get_loss_training(scores=['rmse', 'mae', 'r2'])
 
         # expected output
         expected_output = pd.Series(


### PR DESCRIPTION
Ticket: [2477](https://github.com/enercoop/DataETL/issues/2477)

Minor changes:
- fix/rewrite wape function based on code of mape function in sklearn module
- add argument post_iter_hook in backtest method
- fix scores argument for get_loss_training() function in test_h2o_estimator.py
- fix type hint of scores argument in backtest method